### PR TITLE
Remove toUpperCase call from split function

### DIFF
--- a/benchmark/split.js
+++ b/benchmark/split.js
@@ -20,5 +20,5 @@ module.exports = function split(str) {
         res += parts[i].substring(1);
     }
 
-    return res.toUpperCase();
+    return res;
 };


### PR DESCRIPTION
```
                      pff
       2,631,551 op/s » tiny (prod)
         922,530 op/s » short (prod)
       1,159,801 op/s » tiny (rand)
         656,778 op/s » short (rand)
                      split
       3,104,273 op/s » tiny (prod)
       1,287,170 op/s » short (prod)
       1,201,908 op/s » tiny (rand)
         697,254 op/s » short (rand)
                      indexOf
       1,905,926 op/s » tiny (prod)
         668,812 op/s » short (prod)
       1,426,274 op/s » tiny (rand)
         743,984 op/s » short (rand)
```
